### PR TITLE
Fix img-src and a-href in terminology

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -4,8 +4,7 @@
 
 ### First, a basic hledger transaction with the parts named:
 
-![hledger basic transaction, showing names of parts](https://github.com/RobertNielsen1/hledger/blob/master/hledger%20basic%20transaction%20--%20terms.png)
-(https://raw.githubusercontent.com/RobertNielsen1/hledger/master/hledger%20basic%20transaction%20--%20terms.png)
+[![hledger basic transaction, showing names of parts](https://raw.githubusercontent.com/RobertNielsen1/hledger/master/hledger%20basic%20transaction%20--%20terms.png)](https://github.com/RobertNielsen1/hledger/blob/master/hledger%20basic%20transaction%20--%20terms.png)
 
 ### Second, a more complicated hledger transaction with the parts named: 
 
@@ -14,6 +13,6 @@ Note:
 - The purpose is to show many of the possible parts of an hledger transaction
 - There are possible hledger transaction options that are not included, due mostly to reasons of space and readability
 
-![hledger complicated transaction with names of parts](https://github.com/RobertNielsen1/hledger/blob/master/hledger%20complicated%20transaction%20%26%20terms.png)
+[![hledger complicated transaction with names of parts](https://raw.githubusercontent.com/RobertNielsen1/hledger/master/hledger%20complicated%20transaction%20%26%20terms.png)](https://github.com/RobertNielsen1/hledger/blob/master/hledger%20complicated%20transaction%20%26%20terms.png)
 
 For more information concerning hledger transaction terminology and parts, see http://hledger.org/journal.html.


### PR DESCRIPTION
They are appeared in:
https://github.com/simonmichael/hledger_site/blob/master/terminology.md

but not in:
https://hledger.org/terminology.html