### PR TITLE
(WIP) Update e.g. and i.e. in docs

### DIFF
--- a/accounting-concepts.md
+++ b/accounting-concepts.md
@@ -68,13 +68,13 @@ expenses
   supplies
 ```
 
-In some organisations and accounting systems (eg, QuickBooks), the
+In some organisations and accounting systems (e.g. QuickBooks), the
 tree structure is de-emphasised, so the above is represented more
 like:
 
 ```
  Account name      Account type
- ------------------------------- 
+ -------------------------------
  checking          ASSET
  cash              ASSET
  business income   REVENUE
@@ -190,7 +190,7 @@ $ hledger balance --depth 1
 A transaction is a movement of money from some account(s) to some
 other account(s).  There are many common types of transaction.  A
 purchase is where money moves from an asset account to an expense
-account.  Eg, buying food.
+account.  E.g. buying food.
 
 -->
 

--- a/basics-tutorial.md
+++ b/basics-tutorial.md
@@ -348,7 +348,7 @@ $ hledger register expenses
 2015/05/26 forgot the bread     expenses                        $5           $15
 ```
 
-Now it's clear that your `expenses` balance - ie, the total amount spent - has increased to $15.
+Now it's clear that your `expenses` balance - i.e., the total amount spent - has increased to $15.
 
 Your `assets` balance should have dropped accordingly. Check it:
 

--- a/basics-tutorial.md
+++ b/basics-tutorial.md
@@ -42,13 +42,13 @@ You should see something like:
 ```shell
 $ hledger stats
 The hledger journal file "/home/YOU/.hledger.journal" was not found.
-Please create it first, eg with "hledger add" or a text editor.
+Please create it first, e.g. with "hledger add" or a text editor.
 Or, specify an existing journal file with -f or LEDGER_FILE.
 ```
 
 Most hledger commands read this file but can not change it; the `add` and `web` commands can also write it.
 
-(If `stats` reports that the file exists, eg because you previously created it, move it out of the way temporarily for these exercises.)
+(If `stats` reports that the file exists, e.g., because you previously created it, move it out of the way temporarily for these exercises.)
 
 ## Record a transaction with "hledger add"
 
@@ -78,7 +78,7 @@ Description: trip to the supermarket
 ```
 
 Transactions have an optional description (a single line of text) to help you understand them.
-You can describe the transaction here, or put a payee name, or leave it blank. 
+You can describe the transaction here, or put a payee name, or leave it blank.
 Type `trip to the supermarket` and press enter.
 
 ```shell
@@ -105,7 +105,7 @@ Account 2: assets
 Next, specify which account the money comes from. Just say `assets`.
 
 ```shell
-Amount  2 ? [$-10.0]: 
+Amount  2 ? [$-10.0]:
 ```
 
 Now you're asked for the amount to "move" to or from the `assets` account.
@@ -133,7 +133,7 @@ You are given a chance to review the transaction just entered.
 Here you see hledger's plain text data format for journal entries:
 a non-indented YYYY/MM/DD date, space, and description,
 followed by two or more indented posting lines, each containing an account name,
-two or more spaces, and an amount. 
+two or more spaces, and an amount.
 (Account names can contain spaces, so at least two spaces are needed to separate them from the amount.)
 Press enter.
 
@@ -151,7 +151,7 @@ entry.  Press control-d (on Windows, control-c) once to exit.
 ```shell
 $ hledger stats
 Main journal file        : /home/YOU/.hledger.journal
-Included journal files   : 
+Included journal files   :
 Transactions span        : 2015-05-25 to 2015-05-26 (1 days)
 Last transaction         : 2015-05-25 (0 days ago)
 Transactions             : 1 (1.0 per day)
@@ -202,7 +202,7 @@ Only one missing amount is allowed in each transaction.
 ## Edit the journal file
 
 Since the journal file is plain text, you can edit it directly with any text editor.
-Edit the file and change it to test whether two missing amounts is reported as an error. Eg:
+Edit the file and change it to test whether two missing amounts is reported as an error. E.g.,
 
 ```shell
 $ emacs ~/.hledger.journal
@@ -212,7 +212,7 @@ Remove the expenses amount and save the file. It now looks like this:
 
 ```journal
 2015/05/25 trip to the supermarket
-    expenses           
+    expenses
     assets
 ```
 
@@ -256,7 +256,7 @@ Edit the file to look like this:
 ```
 
 Here, we wrote both posting amounts but got the sign wrong on one of them, so they don't add up to zero.
-hledger should detect this mistake. Verify it by running some command, eg `print`. You should see:
+hledger should detect this mistake. Verify it by running some command, e.g. `print`. You should see:
 
 ```shell
 $ hledger print
@@ -434,7 +434,7 @@ $ hledger balance
 ```
 
 The overall total of these balances is also shown. As with other reports, you can use a query expression to select a subset of the data to report on.
-Eg:
+E.g.,
 
 ```shell
 $ hledger balance assets

--- a/contributors.md
+++ b/contributors.md
@@ -33,7 +33,7 @@ hledger, please sign this, to help ensure:
 2.  that you get proper credit for your work
 
 3.  that we are able to remain license-compatible with related software
-    by updating to newer versions of our license when appropriate (eg
+    by updating to newer versions of our license when appropriate (e.g.
     GPLv2 -\> GPLv3)
 
 To "sign", read the conditions below and then send a darcs patch to

--- a/convert-csv-files.md
+++ b/convert-csv-files.md
@@ -10,8 +10,8 @@ Say we have downloaded `checking.csv` from a bank for the first time:
 ```
 
 We tell hledger how to intepret this with a file named
-`checking.csv.rules`, using the 
-[CSV rules syntax](csv.html). Eg:
+`checking.csv.rules`, using the
+[CSV rules syntax](csv.html). E.g.,
 
 ```rules
 # skip the first CSV line (headings)

--- a/create-a-journal.md
+++ b/create-a-journal.md
@@ -9,8 +9,8 @@ The simplest possible journal is just an empty file:
     touch 2018.journal
 
 
-The name doesn't matter much and can be changed later. 
-One file per year is common, 
+The name doesn't matter much and can be changed later.
+One file per year is common,
 and so is a `.journal` or `.hledger` extension.
 
 ## with cat
@@ -22,9 +22,9 @@ and so is a `.journal` or `.hledger` extension.
       assets:cash
     <CTRL-D>
 
-[Account names](journal.html#account-names) can be anything 
-and you can change them later by search and replace. 
-If you don't know what to [choose](http://plaintextaccounting.org/#choosing-accounts), 
+[Account names](journal.html#account-names) can be anything
+and you can change them later by search and replace.
+If you don't know what to [choose](http://plaintextaccounting.org/#choosing-accounts),
 start with these five:\
 `expenses`, `income`, `assets`, `liabilities`, and `equity`,\
 perhaps with one extra subcategory as above.
@@ -32,7 +32,7 @@ perhaps with one extra subcategory as above.
 ## with a text editor
 
 Write transactions in a text editor, optionally using an
-[editor mode](editors.html), 
+[editor mode](editors.html),
 and save the file.
 
 ## with hledger add
@@ -42,9 +42,9 @@ Use the interactive [add](hledger.html#add) command to enter one or more transac
     hledger add -f 2018.journal
 
 
-To avoid typing `-f FILE` every time, set the 
-[`LEDGER_FILE` environment variable](hledger.html#input-files). 
-Eg:
+To avoid typing `-f FILE` every time, set the
+[`LEDGER_FILE` environment variable](hledger.html#input-files).
+E.g.,
 
     echo "export LEDGER_FILE=~/finance/2018.journal" >> ~/.bash_profile && source ~/.bash_profile
 

--- a/customize-default-csv-accounts.md
+++ b/customize-default-csv-accounts.md
@@ -2,9 +2,9 @@
 
 When converting CSV, hledger uses the account names `income:unknown` and `expenses:unknown` as defaults for the second posting's account.
 
-Normally when you see these, you will add CSV rules to set a more specific account name. 
+Normally when you see these, you will add CSV rules to set a more specific account name.
 But they should probably be configurable.
-Here are some ways to customize them for now. 
+Here are some ways to customize them for now.
 
 ## By CSV rule
 
@@ -25,7 +25,7 @@ if cafe
   account2 Expenses:Coffee
 ```
 
-Add two rules like this, before any other account2 rules (eg above the `if cafe` rule):
+Add two rules like this, before any other account2 rules (e.g. above the `if cafe` rule):
 ```
 # default income/expense accounts
 account2 Income:Misc
@@ -33,7 +33,7 @@ if ,-[0-9]+(,|$)
  account2 Expenses:Misc
 ```
 
-The first sets the account to Income:Misc, 
+The first sets the account to Income:Misc,
 and the second changes it to Expenses:Misc if the amount field is negative.
 The regular expression matching negative amounts works for the example above, but you may need to adapt it for your data.
 

--- a/download.md
+++ b/download.md
@@ -1,14 +1,14 @@
 # Download/Install
 
 <style>
-table#downloads > tbody > tr { 
-  border-bottom:thin solid #ddd; 
+table#downloads > tbody > tr {
+  border-bottom:thin solid #ddd;
 }
-table#downloads > tbody > tr > td { 
+table#downloads > tbody > tr > td {
   padding-top:0.5em;
   padding-bottom:0.5em;
 }
-table#downloads > tbody > tr > td:nth-child(2) { 
+table#downloads > tbody > tr > td:nth-child(2) {
   padding-top:1.5em;
 }
 div.section > table td:first-child {
@@ -29,7 +29,7 @@ div.command {
   margin-bottom:1em;
 }
 div.builder {
-  border-top:thin solid #ddd; 
+  border-top:thin solid #ddd;
   padding-top:0.5em;
   font-size:big;
   font-weight:bold;
@@ -86,9 +86,9 @@ Here are the [release notes](release-notes) describing each version.
         </div>
         <div class="notes">
             In the first days after release, this may do some building (not fully cached yet)
-            or fail with "HTTP error 404" (not built for your platform yet); 
+            or fail with "HTTP error 404" (not built for your platform yet);
             try it with --dry-run to see.
-            On Linux, note <span class="warnings"><a href="https://github.com/simonmichael/hledger/issues/1030">#1030</a>, 
+            On Linux, note <span class="warnings"><a href="https://github.com/simonmichael/hledger/issues/1030">#1030</a>,
             <a href="https://github.com/simonmichael/hledger/issues/1033">#1033</a>.
         </div>
       </td>
@@ -292,8 +292,8 @@ On Windows, hledger-ui is not available and should be omitted from the commands 
 </div>
 <div class="builder-text">
   The hledger-install script is a robust install method that requires only
-  <a href=https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29">bash</a>. 
-  It runs stack or cabal for you, installing stack if you have neither, 
+  <a href=https://en.wikipedia.org/wiki/Bash_%28Unix_shell%29">bash</a>.
+  It runs stack or cabal for you, installing stack if you have neither,
   and installs all the main hledger tools and some <a href="hledger.html#add-on-commands">add‑on commands</a>,
   in ~/.local/bin or ~/.cabal/bin.
 </div>
@@ -394,7 +394,7 @@ On Windows, the 64-bit version of stack is recommended.
 
 The master branch in hledger's github repo is suitable for daily use,
 and includes the [latest improvements](https://github.com/simonmichael/hledger/commits/master).
-You'll need [git](https://en.wikipedia.org/wiki/Git) and 
+You'll need [git](https://en.wikipedia.org/wiki/Git) and
 [stack](https://haskell.fpcomplete.com/get-started) or [cabal](https://www.haskell.org/cabal/).
 This will build and install all of the main hledger tools using stack:
 
@@ -429,7 +429,7 @@ image for hledger development, run `./build-dev.sh` instead.
 ## Check your PATH
 
 After building/installing, you may see a message about where the executables were installed.
-Eg:
+E.g.,
 
 - with stack: `$HOME/.local/bin` (on Windows, `%APPDATA%\local\bin`)
 - with cabal: `$HOME/.cabal/bin` (on Windows, `%APPDATA%\cabal\bin`)
@@ -455,7 +455,7 @@ and here's a way to add the stack and cabal install dirs permanently:
 ## Test your installation
 
 After a successful installation, you should be able to run the hledger
-tools (that you installed), and see the expected versions. Eg:
+tools (that you installed), and see the expected versions. E.g.,
 
 <div class="command">
 $ hledger --version <br>
@@ -478,7 +478,7 @@ All 190 tests passed (4.30s)
 
 Nicely done! Next, see the Getting Started docs in the sidebar, such
 as the **[Basics tutorial](basics-tutorial.html)**,
-or come to the **[IRC channel/Matrix room](index.html#help-feedback)** 
+or come to the **[IRC channel/Matrix room](index.html#help-feedback)**
 where we'll help you out, or gladly hear your feedback.
 
 <br>

--- a/editors.md
+++ b/editors.md
@@ -33,11 +33,11 @@ with a command or arguments that hledger doesn't support. In this case you can
 
 - open an ledger-mode issue, asking, suggesting how, and/or
   providing a pull request to make it more hledger-compatible (best)
-  
-- do something locally to keep ledger-mode happy, eg define a
+
+- do something locally to keep ledger-mode happy, e.g., define a
   small add-on command mimicking the required ledger command.
 
-Eg: `ledger-display-balance-at-point` (C-c C-p) runs 
+E.g., `ledger-display-balance-at-point` (C-c C-p) runs
 `ledger cleared ACCT`.
 hledger doesn't have a "cleared" command, so you could make it by
 creating `hledger-cleared.sh` in $PATH:
@@ -53,7 +53,7 @@ To toggle just a posting's status: move point to it, C-c C-c.
 
 ## Emacs tips
 
-Ledger entries can be embedded in a org file and manipulated using Babel. See eg
+Ledger entries can be embedded in a org file and manipulated using Babel. See e.g.
 [Using Ledger for Accounting in Org-mode with Babel](https://orgmode.org/worg/org-contrib/babel/languages/ob-doc-ledger.html)
 
 A helper to browse TODO tags in the journal:

--- a/faq.md
+++ b/faq.md
@@ -40,14 +40,14 @@ If you add a few directives to the file, hledger can:
 - include multiple data sets
 - generate recurring transactions by rule
 - add extra postings (splits) to transactions by rule
-- show a forecast of future activity, eg to help with cashflow planning
+- show a forecast of future activity, e.g. to help with cashflow planning
 - make a budget report, showing your budget goals and status by account and period
 
 Also, it can:
 
 - generate interest transactions by rule
 - help you enter new transactions with prompts or a terminal UI
-- help you convert and import new transactions from external sources, eg banks
+- help you convert and import new transactions from external sources, e.g. banks
 - be used as a library in a quick Haskell script or compiled program
 
 ## How could that help me ?
@@ -102,9 +102,9 @@ It's resizable.
 You can pick the font and colours.
 You do not need "Plaintext Reader, Trial Version" to read it.
 you do not need "Plaintext Studio Pro" to write it.
-You can use your favorite editor and skills you already have. 
-You can search in it! 
-You can version control it. 
+You can use your favorite editor and skills you already have.
+You can search in it!
+You can version control it.
 It works well over remote/slow connections.
 It's future-proof.
 It will be just as usable in 15 or 50 years.
@@ -118,7 +118,7 @@ efficiently. So, we store it as human-readable plain text.*
 
 ## Isn't this too weird for my family, business partners, tax accountant to use ?
 
-Maybe. You can ask them to enter data via hledger-web, 
+Maybe. You can ask them to enter data via hledger-web,
 or import from their mobile expenses app or a shared spreadsheet.
 You can show them the hledger-web UI, or HTML reports, or give them CSV to open in a spreadsheet.
 
@@ -177,7 +177,7 @@ and now [plaintextaccounting.org](http://plaintextaccounting.org).
 
 hledger's journal file format is very similar to Ledger's.
 Some syntactic forms can be interpreted in slightly different ways,
-eg [hledger comments](journal.html#comments) 
+e.g. [hledger comments](journal.html#comments)
 vs [Ledger comments](https://www.ledger-cli.org/3.0/doc/ledger3.html#Commenting-on-your-Journal),
 or [balance assertions](journal.html#assertions-and-ordering).
 
@@ -186,7 +186,7 @@ or rejected (value expressions). If you avoid these, it's quite easy
 to keep a journal file that works with both hledger and Ledger.
 
 Or, you can keep the hledger- and Ledger-specific bits in separate files,
-both [including](journal.html#including-other-files) a common file. Eg:
+both [including](journal.html#including-other-files) a common file. E.g.,
 ```shell
 $ ls *.journal
 common.journal   # included by hledger.journal and ledger.journal
@@ -267,26 +267,26 @@ We do not yet support:
 #### Command line interface
 
 - hledger does not require a space between command-line flags and their values,
-  eg `-fFILE` works as well as `-f FILE`
+  e.g. `-fFILE` works as well as `-f FILE`
 
 - hledger's `-b`, `-e`, `-D`, `-W`, `-M`, `-Q`, `-Y` and `-p` options combine nicely.
   You can also specify start and/or end dates with a query argument,
-  eg `date:START-` or `date:START-END`.
+  e.g. `date:START-` or `date:START-END`.
 
 - hledger's [query language](hledger.html#queries) is a little less
   powerful than Ledger's, simpler, and easier to remember.
-  It uses google-like prefixes, eg `desc:`, `payee:`, `amt:`, `not:`.
+  It uses google-like prefixes, e.g. `desc:`, `payee:`, `amt:`, `not:`.
   Multiple patterns are combined using fixed AND/OR rules.
   We don't yet support full boolean expressions, so some more advanced
-  queries require two invocations of hledger in a pipe, eg: 
+  queries require two invocations of hledger in a pipe, e.g.,
   `hledger print QUERY1 | hledger -f- reg QUERY2`
 
-- hledger uses `--ignore-assertions`/`-I` to disable balance assertions. 
+- hledger uses `--ignore-assertions`/`-I` to disable balance assertions.
   Ledger uses `--permissive` for that, and uses `-I` as the short form of `--prices`.
 
 - hledger cleans up some semantic confusion with status matching (#564):
 
-  - hledger uses `-P` as the short form of `--pending`. Ledger uses it for grouping by payee. 
+  - hledger uses `-P` as the short form of `--pending`. Ledger uses it for grouping by payee.
   - hledger renames Ledger's "uncleared" status (ie, when the status field
     is empty) to "unmarked", and the `--uncleared`/`-U` flag to `--unmarked`/`-U`
   - each of hledger's `--unmarked`/`-U`, `--pending`/`-P`, `--cleared`/`-C` flags match only that single status.
@@ -317,7 +317,7 @@ We do not yet support:
       --historical (-H)
                                 Value commodities at the time of their acquisition.
 
-- hledger's `-x`/`--explicit` flag (makes print show all amounts) 
+- hledger's `-x`/`--explicit` flag (makes print show all amounts)
   and Ledger's `--explicit` flag (does something else) are unrelated.
 
 #### journal format
@@ -327,11 +327,11 @@ We do not yet support:
   space) and digit group sizes to use for each commodity. Or, these can
   be declared explicitly with commodity directives.
 
-- hledger applies [balance assignments](journal.html#balance-assignments) 
+- hledger applies [balance assignments](journal.html#balance-assignments)
   and checks [balance assertions](journal.html#balance-assertions)
   in date order (and then by parse order, for postings on the same date).
   This ensures correct, deterministic behaviour, independent of the ordering of
-  journal entries and files. 
+  journal entries and files.
   Ledger checks assertions in the order they are parsed (ignoring dates), which is fragile.
 
   Also, hledger correctly handles multiple balance assignments/assertions in a single transaction.
@@ -349,11 +349,11 @@ We do not yet support:
 
 #### timeclock & timedot formats
 
-- hledger's journal, timeclock and timedot formats are separate; you can't 
+- hledger's journal, timeclock and timedot formats are separate; you can't
   mix them all in one file as in Ledger.
   (Though you can specify all files on the command line, or have a parent journal file include them all.)
   This simplifies the implementation and helps ensure useful parse error messages.
-  
+
 - hledger always shows time balances (from the timeclock/timedot formats) in hours
 
 #### timeclock format
@@ -364,8 +364,8 @@ We do not yet support:
 ## What is ledger4 ?
 
 [ledger4](https://github.com/ledger/ledger4) was John's 2012 start
-at rewriting parts of Ledger 3, eg the parser, in Haskell.
-We included this in hledger for a while, 
+at rewriting parts of Ledger 3, e.g. the parser, in Haskell.
+We included this in hledger for a while,
 hoping to attract contributions to improve this "bridge" between the projects,
 and improve our support for reading Ledger's files.
 After some time it was removed again.
@@ -382,10 +382,10 @@ Some quick/rough migration recipes:
 4. `cd ~/Downloads` (or wherever you saved it)
 5. `hledger import mint.csv`
 
-Now `hledger stats` and `hledger bal` should show lots of data. That's your past data migrated. 
+Now `hledger stats` and `hledger bal` should show lots of data. That's your past data migrated.
 
 Then, if you want to leave Mint, you'll need to replace their automatic
-import from banks with 
+import from banks with
 [your own import process](#isn-t-importing-from-banks-a-pain).
 
 Or if you want to keep using Mint for that, because you like how they
@@ -411,23 +411,23 @@ This is documented at [journal format: directives](journal.html#directives).
 (Also mentioned at [hledger: Input files](hledger.html#input-files).)
 These docs could be improved.
 
-Directives which affect parsing of data vary in their scope, 
-ie the area of input data they affect. Eg, should they affect: 
+Directives which affect parsing of data vary in their scope,
+ie the area of input data they affect. E.g., should they affect:
 
-- entries after the directive, in this file only ? 
-  - Eg: 
-    `alias`, 
-    `apply account`, 
-    `comment`, 
+- entries after the directive, in this file only ?
+  - E.g.,
+    `alias`,
+    `apply account`,
+    `comment`,
     `Y`
 - entries before and after the directive, in this file only ?
 - entries and included files after the directive, until this file's end ?
 - all entries after the directive, in this and all included or subsequent files, including parent files ?
-  - Eg: 
+  - E.g.,
     the number notation specified by `D`
     or `commodity`
 - all entries in all files ?
-  - Eg: 
+  - E.g.,
     the default commodity specified by `D`,
     and `account`
 
@@ -457,7 +457,7 @@ Some of hledger's older commands (balance, print, register) show a
 multi-commodity amount with each commodity on its own line, by default
 (like Ledger).
 
-Here are some examples. 
+Here are some examples.
 In the following journal entry, the implicit balancing amount drawn from the `b` account will be a multicommodity amount (a euro and a dollar):
 ```journal
 2015/1/1
@@ -489,8 +489,8 @@ and a multi-commodity amount in the third posting:
 ```shell
 $ hledger -f t.j register --width 50
 2015/01/01       a             EUR 1         EUR 1
-                 a             USD 1         EUR 1  ; <- the running total is now a euro and a dollar        
-                                             USD 1  ;                                                        
+                 a             USD 1         EUR 1  ; <- the running total is now a euro and a dollar
+                                             USD 1  ;
                  b            EUR -1                ; <- the amount posted to b is a negative euro and dollar
                               USD -1             0  ;
 ```
@@ -501,12 +501,12 @@ Although wider, this seems clearer and we should probably use it more:
 $ hledger -f t.j balance --yearly
 Balance changes in 2015:
 
-   ||           2015 
+   ||           2015
 ===++================
- a ||   EUR 1, USD 1 
- b || EUR -1, USD -1 
+ a ||   EUR 1, USD 1
+ b || EUR -1, USD -1
 ---++----------------
-   ||              0 
+   ||              0
 ```
 
 You will also see amounts without a corresponding account name if you
@@ -514,10 +514,10 @@ remove too many account name segments with [`--drop`](hledger.html#balance)
 (a bug, which we'd like to see fixed):
 ```shell
 $ hledger -f t.j balance --drop 1
-               EUR 1  
-               USD 1  
-              EUR -1  
-              USD -1  
+               EUR 1
+               USD 1
+              EUR -1
+              USD -1
 --------------------
                    0
 ```
@@ -525,10 +525,10 @@ $ hledger -f t.j balance --drop 1
 
 ## With hledger-ui in iTerm2/3, why does Shift-Up/Shift-Down move the cursor instead of adjusting the period ?
 
-One way to fix: in iTerm2 do Preferences -> Profiles -> your current profile -> Keys -> Load Preset -> xterm Defaults 
-(not Terminal.app Compatibility). And perhaps open a new tab with this profile. 
+One way to fix: in iTerm2 do Preferences -> Profiles -> your current profile -> Keys -> Load Preset -> xterm Defaults
+(not Terminal.app Compatibility). And perhaps open a new tab with this profile.
 
-<!-- 
+<!--
 
 ## How do I set the LEDGER_FILE environment variable on Windows?
 

--- a/faq.md
+++ b/faq.md
@@ -287,11 +287,11 @@ We do not yet support:
 - hledger cleans up some semantic confusion with status matching (#564):
 
   - hledger uses `-P` as the short form of `--pending`. Ledger uses it for grouping by payee.
-  - hledger renames Ledger's "uncleared" status (ie, when the status field
+  - hledger renames Ledger's "uncleared" status (i.e., when the status field
     is empty) to "unmarked", and the `--uncleared`/`-U` flag to `--unmarked`/`-U`
   - each of hledger's `--unmarked`/`-U`, `--pending`/`-P`, `--cleared`/`-C` flags match only that single status.
     To match more than one status, the flags can be combined.
-    So the hledger equivalent of `ledger print -U` (ie: match all but
+    So the hledger equivalent of `ledger print -U` (i.e., match all but
     cleared transactions) is `hledger print -UP`.
 
 - hledger print shows both the primary date and the secondary date if any, always.
@@ -412,7 +412,7 @@ This is documented at [journal format: directives](journal.html#directives).
 These docs could be improved.
 
 Directives which affect parsing of data vary in their scope,
-ie the area of input data they affect. E.g., should they affect:
+i.e. the area of input data they affect. E.g., should they affect:
 
 - entries after the directive, in this file only ?
   - E.g.,

--- a/foreign-trip-expenses.md
+++ b/foreign-trip-expenses.md
@@ -44,7 +44,7 @@ My attempt follows. Notes:
     Assets:Cash
 
 ; Conversion rate to use in reports for the trip period.
-; You could declare each time it changed, eg:
+; You could declare each time it changed, e.g.,
 ; P 2018-10-25 EUR 1.10 USD
 ; P 2018-10-28 EUR 1.20 USD
 ; but hledger currently picks just one,
@@ -58,14 +58,14 @@ Simple balance change report for all accounts. --flat and -Y help ensure a reada
 $ hledger bal --flat -Y
 Balance changes in 2018:
 
-                                  ||                 2018 
+                                  ||                 2018
 ==================================++======================
- Assets:Bank                      ||          -590.00 USD 
- Expenses:Fees:CurrencyConversion ||            10.00 USD 
- Expenses:Vacation:Food           ||              190 EUR 
- Expenses:Vacation:Hotel          ||              310 EUR 
+ Assets:Bank                      ||          -590.00 USD
+ Expenses:Fees:CurrencyConversion ||            10.00 USD
+ Expenses:Vacation:Food           ||              190 EUR
+ Expenses:Vacation:Hotel          ||              310 EUR
 ----------------------------------++----------------------
-                                  || 500 EUR, -580.00 USD 
+                                  || 500 EUR, -580.00 USD
 ```
 
 Adding the -B/--cost flag converts transaction amounts to the other commodity in the transaction, using the conversion rate specified in the transaction if any. This typically helps collapse the grand total to one commodity, so we can see it is zero here (expected, since we're showing all accounts).
@@ -73,34 +73,34 @@ Adding the -B/--cost flag converts transaction amounts to the other commodity in
 $ hledger bal --flat -Y -B
 Balance changes in 2018:
 
-                                  ||                 2018 
+                                  ||                 2018
 ==================================++======================
- Assets:Bank                      ||          -590.00 USD 
- Assets:Cash                      || -500 EUR, 580.00 USD 
- Expenses:Fees:CurrencyConversion ||            10.00 USD 
- Expenses:Vacation:Food           ||              190 EUR 
- Expenses:Vacation:Hotel          ||              310 EUR 
+ Assets:Bank                      ||          -590.00 USD
+ Assets:Cash                      || -500 EUR, 580.00 USD
+ Expenses:Fees:CurrencyConversion ||            10.00 USD
+ Expenses:Vacation:Food           ||              190 EUR
+ Expenses:Vacation:Hotel          ||              310 EUR
 ----------------------------------++----------------------
-                                  ||                    0 
+                                  ||                    0
 ```
 
 Adding the -V/--value flag instead converts report amounts using the market price effective on the reporting date (hledger prices and date can help identify that). The grand total of -5 USD here corresponds to our capital loss due to change in exchange rate (the price of a euro went from $1.10 to $1.20 while we still owed some):
 ```
-$ hledger prices 
+$ hledger prices
 P 2018-10-25 EUR 1.15 USD
 $ date
 Fri Oct 26 15:03:00 PDT 2018
 $ hledger bal --flat -Y -V
 Balance changes in 2018:
 
-                                  ||        2018 
+                                  ||        2018
 ==================================++=============
- Assets:Bank                      || -590.00 USD 
- Expenses:Fees:CurrencyConversion ||   10.00 USD 
- Expenses:Vacation:Food           ||  218.50 USD 
- Expenses:Vacation:Hotel          ||  356.50 USD 
+ Assets:Bank                      || -590.00 USD
+ Expenses:Fees:CurrencyConversion ||   10.00 USD
+ Expenses:Vacation:Food           ||  218.50 USD
+ Expenses:Vacation:Hotel          ||  356.50 USD
 ----------------------------------++-------------
-                                  ||   -5.00 USD 
+                                  ||   -5.00 USD
 ```
 
 The "exp" account query is added to show just the expenses. Now we can see their total.
@@ -108,13 +108,13 @@ The "exp" account query is added to show just the expenses. Now we can see their
 $ hledger bal --flat -Y -V exp
 Balance changes in 2018:
 
-                                  ||       2018 
+                                  ||       2018
 ==================================++============
- Expenses:Fees:CurrencyConversion ||  10.00 USD 
- Expenses:Vacation:Food           || 218.50 USD 
- Expenses:Vacation:Hotel          || 356.50 USD 
+ Expenses:Fees:CurrencyConversion ||  10.00 USD
+ Expenses:Vacation:Food           || 218.50 USD
+ Expenses:Vacation:Hotel          || 356.50 USD
 ----------------------------------++------------
-                                  || 585.00 USD 
+                                  || 585.00 USD
 ```
 
 Or you might use the is/incomestatement command which is specialised for income/expense reporting.
@@ -123,20 +123,20 @@ It's tabular and flat by default.
 $ hledger is -V
 Income Statement 2018/10/25-2018/10/28
 
-                                  || 2018/10/25-2018/10/28 
+                                  || 2018/10/25-2018/10/28
 ==================================++=======================
- Revenues                         ||                       
+ Revenues                         ||
 ----------------------------------++-----------------------
 ----------------------------------++-----------------------
-                                  ||                       
+                                  ||
 ==================================++=======================
- Expenses                         ||                       
+ Expenses                         ||
 ----------------------------------++-----------------------
- Expenses:Fees:CurrencyConversion ||             10.00 USD 
- Expenses:Vacation:Food           ||            218.50 USD 
- Expenses:Vacation:Hotel          ||            356.50 USD 
+ Expenses:Fees:CurrencyConversion ||             10.00 USD
+ Expenses:Vacation:Food           ||            218.50 USD
+ Expenses:Vacation:Hotel          ||            356.50 USD
 ----------------------------------++-----------------------
-                                  ||            585.00 USD 
+                                  ||            585.00 USD
 ==================================++=======================
- Net:                             ||           -585.00 USD 
+ Net:                             ||           -585.00 USD
 ```

--- a/gains-model.md
+++ b/gains-model.md
@@ -25,7 +25,7 @@ may be better accounting terms I'm not familiar with yet.
 
 - You might have paid current market value for the lot, or you might have
   paid less or more than that. We'll call what you paid/exchanged the *acquisition amount*.
-  
+
 - I think the acquisition amount is also called the *basis* or *cost basis*.
   Or possibly the current market value is the basis, regardless of what you paid.
   Perhaps it depends. To be clarified. The basis at which you acquired a lot is important.
@@ -37,7 +37,7 @@ may be better accounting terms I'm not familiar with yet.
   This is not considered revenue, or taxable.
 
 - It's common to be holding multiple lots, perhaps many, even in a single account.
-  Eg, say you buy a small amount of some stock or cryptocurrency each week.
+  E.g., say you buy a small amount of some stock or cryptocurrency each week.
   Each purchase adds a new lot to your assets. We'll call this a *multi-lot balance*, or *balance*.
 
 - URG is calculated for a lot at a certain point in time.

--- a/index.md
+++ b/index.md
@@ -12,8 +12,8 @@ Easy plain text accounting.
 
 <img id="coins" src="_static/images/coins2-248.png" style="width:33%; float:right; margin:1em 1em 0 1em;" />
 
-<span style="font-size:x-large;">hledger</span> 
-is an elegant, versatile accounting program, 
+<span style="font-size:x-large;">hledger</span>
+is an elegant, versatile accounting program,
 for tracking money, time, or other commodities,
 on unix, mac and windows,
 with command line, terminal and web interfaces.
@@ -24,7 +24,7 @@ Quicken, Xero, or GnuCash.
 
 hledger is one of the leading implementations of [plain text accounting](http://plaintextaccounting.org),
 and is a modern and largely compatible reimplementation of [Ledger](https://ledger-cli.org).
-Compared to [the others](https://plaintextaccounting.org/#software), 
+Compared to [the others](https://plaintextaccounting.org/#software),
 hledger is robust, consistent, and intuitive, with excellent documentation.
 
 hledger is cross platform GNU GPLv3 free software, written in Haskell.
@@ -56,7 +56,7 @@ You can start very simply, and get more sophisticated as you learn more about do
 
 There is an enthusiastic and growing community practising this way of accounting.
 which can be quite educational and enjoyable.
-If you'd like more background, 
+If you'd like more background,
 we have collected many useful resources at plaintextaccounting.org (see link above).
 
 Read on for more about hledger, or if you're keen to get going,
@@ -113,7 +113,7 @@ that lets you review account balances and transactions quickly and without fuss.
 And, a zero-setup
 [web&nbsp;app](hledger-web) for a more point-and-click experience
 ([demo](http://demo.hledger.org)).
-Run it on your local machine, or on a server, 
+Run it on your local machine, or on a server,
 or set it up with a few clicks on
 [Sandstorm](https://apps.sandstorm.io/app/8x12h6p0x0nrzk73hfq6zh2jxtgyzzcty7qsatkg7jfg2mzw5n90).
 
@@ -148,15 +148,15 @@ applications.
 
 ### fully documented
 
-We practice documentation-driven development. 
-Every feature must be **well documented**, 
+We practice documentation-driven development.
+Every feature must be **well documented**,
 and getting started must be easy.
 
 ### focussed on serving users
 
 hledger strives to be usable, practical and to provide real-world value.
 Intuitive features, bug-free operation and complete, accurate documentation are top goals.
-Currently it is particularly suited to techies, ie users who appreciate the
+Currently it is particularly suited to techies, i.e. users who appreciate the
 power of text files, revision control, scriptability and double entry
 accounting.
 
@@ -232,8 +232,8 @@ h1 { font-size:4em; margin-bottom:.3em; }
 
 #tagline {
   font-size:xx-large;
-  font-style:italic; 
-  position:relative; 
+  font-style:italic;
+  position:relative;
   top:-.5em;
   left:.5em;
   /*text-align:right;*/

--- a/price-syntax.md
+++ b/price-syntax.md
@@ -8,15 +8,15 @@ WIP
   (A timestamp may be added, but is ignored.)
 
 - In a posting, `AMT @ UNITPRICE` declares the per-unit price that was used to convert AMT into the price's commodity.
-  Eg: `2A @ 3B` records that 2A was posted, in exchange for 6B.
+  E.g., `2A @ 3B` records that 2A was posted, in exchange for 6B.
 
 - `@@ TOTALPRICE` is another form of `@`, sometimes more convenient.
-  Eg: `2A @@ 5.99B` records that 2A was posted in exchange for 5.99B.
+  E.g., `2A @@ 5.99B` records that 2A was posted in exchange for 5.99B.
 
 ## In Ledger
 
 - Any use of `@` also generates an implicit `P` directive.
-  Eg:
+  E.g.,
 
       2019/1/1
         a  2A @ 3B
@@ -36,7 +36,7 @@ These need testing:
 
 - `{`` UNITPRICE}` is like `@` but it also causes capital gains transactions to be generated
 
-- a `@`/`@@` and a `{ }`/`{{ }}`/`{ `` }`/ may be combined; the first is used 
+- a `@`/`@@` and a `{ }`/`{{ }}`/`{ `` }`/ may be combined; the first is used
 
 ## In hledger
 

--- a/project-accounting.md
+++ b/project-accounting.md
@@ -9,10 +9,10 @@ Revenue is declared when work is performed:
 ```journal
 ; budget:* - virtual accounts tracking what customers have committed
 ; to pay for various things. Should not go below 0.
-2017/10/30 Order from CUSTOMER (order id) 
+2017/10/30 Order from CUSTOMER (order id)
     (budget:CUSTOMER:PROJECT_ID:pos1)                       1000
     (budget:CUSTOMER:PROJECT_ID:pos2)                       3000
-     
+
 ; some work was done on pos1 and pos2, invoice for it.
 ; Using accrual accounting method
 ; (revenue is declared when work is done, ~= when invoiced)
@@ -22,7 +22,7 @@ Revenue is declared when work is performed:
     assets:receivable:CUSTOMER:PROJECT_ID:pos1               500
     assets:receivable:CUSTOMER:PROJECT_ID:pos2              1000
     revenues:CUSTOMER
-    (liabilities:tax:federal)                               -150  ; note tax due, eg 15% of revenue
+    (liabilities:tax:federal)                               -150  ; note tax due, e.g. 15% of revenue
 
 ; a customer payment is received
 2017/11/15 Payment for INVOICE_ID
@@ -41,7 +41,7 @@ Revenue is declared when work is performed:
 Revenue is declared when payment is received:
 
 ```journal
-2017/10/30 Order from CUSTOMER (order id) 
+2017/10/30 Order from CUSTOMER (order id)
     (budget:CUSTOMER:PROJECT_ID:pos1)                       1000
     (budget:CUSTOMER:PROJECT_ID:pos2)                       3000
 
@@ -58,7 +58,7 @@ Revenue is declared when payment is received:
     (assets:receivable:CUSTOMER:PROJECT_ID:pos1)            -500
     (assets:receivable:CUSTOMER:PROJECT_ID:pos2)           -1000
     revenues:CUSTOMER                                      -1500
-    (liabilities:tax:federal)                               -150  ; note tax due, eg 15% of revenue
+    (liabilities:tax:federal)                               -150  ; note tax due, e.g. 15% of revenue
     assets:bank:checking
 
 ; make a tax payment

--- a/queries.md
+++ b/queries.md
@@ -9,10 +9,10 @@ From the hledger manual's [QUERIES](https://hledger.org/hledger.html#queries) se
 
 Here are some more notes on this subject:
 
-- <https://github.com/simonmichael/hledger/issues/203#issuecomment-369972593>  
+- <https://github.com/simonmichael/hledger/issues/203#issuecomment-369972593>
   When query expressions aren't expressive enough, it's common practice to pipe two hledger commands together in a pipe. First a `print` command to select a subset of transactions, then a second command operating on the first command's output. (The output of `print` is always valid journal format.)
 
-    Eg, which part of salary income went to checking ?
+    E.g., which part of salary income went to checking ?
     ```shell
     $ hledger print income:salary | hledger -f- balance assets:checking
     ```

--- a/save-frequently-used-options.md
+++ b/save-frequently-used-options.md
@@ -1,6 +1,6 @@
 # Save frequently used options
 
-You can save frequently used options and arguments in an 
+You can save frequently used options and arguments in an
 [argument file](hledger.html#argument-files), one per
 line, then reuse them via a @FILE argument on the command line.
 
@@ -27,7 +27,7 @@ by all of the above options/flags.
 
 (In case you're wondering about this example: it removes some detail, giving simplified reports which were easier for me to read at a glance):
 
-- the [aliases](journal.html#rewriting-accounts) simplify the chart of accounts, hiding some distinctions (eg business vs. personal) and flattening some bank account names
+- the [aliases](journal.html#rewriting-accounts) simplify the chart of accounts, hiding some distinctions (e.g. business vs. personal) and flattening some bank account names
 - the `-2` [depth flag](hledger.html#depth-limiting) limits account depth to 2, hiding deeper subaccounts
 - the `cur:.` [query argument](hledger.html#queries) shows only single-character currencies, hiding a bunch of cluttersome commodities I don't want to see
 
@@ -43,21 +43,21 @@ $ hledger-ui --watch @simple.args assets
 ```
 
 Options in the arguments file can be overridden by similar options later on
-the command line, in the [usual way](hledger.html#options). 
-Eg, to show just a little more account detail:
+the command line, in the [usual way](hledger.html#options).
+E.g., to show just a little more account detail:
 ```shell
 $ hledger bal @simple.args -3
 ```
 
 ## Suppressing this feature
 
-If you actually need to write an argument beginning with @, 
-eg let's say you have an account pattern beginning with that character, 
-you'll want a way to disable this feature.  On unix systems at least, 
-you can do that by inserting a `--` (double hyphen) argument first. Eg:
+If you actually need to write an argument beginning with @,
+e.g., let's say you have an account pattern beginning with that character,
+you'll want a way to disable this feature.  On unix systems at least,
+you can do that by inserting a `--` (double hyphen) argument first. E.g.,
 ```
 $ hledger bal @somewhere.com       # looks for additional arguments in the ./somewhere.com file
 $ hledger bal -- @somewhere.com    # matches account names containing "@somewhere.com"
 ```
 
-On windows, this double hyphen trick [might](https://ghc.haskell.org/trac/ghc/ticket/13287) require a hledger built with GHC 8.2+. 
+On windows, this double hyphen trick [might](https://ghc.haskell.org/trac/ghc/ticket/13287) require a hledger built with GHC 8.2+.

--- a/simons-setup.md
+++ b/simons-setup.md
@@ -1,11 +1,11 @@
 # Simon's setup
 
-Author:       Simon Michael  
-Last updated: 201903  
-Tested on:    mac mojave  
-Tested with:  hledger 1.14  
-Tools used: 
-hledger, 
+Author:       Simon Michael
+Last updated: 201903
+Tested on:    mac mojave
+Tested with:  hledger 1.14
+Tools used:
+hledger,
 hledger-ui,
 GNU make,
 ...
@@ -42,11 +42,11 @@ It includes:
 - YEAR.prices containing P records for the year
 - forecast.journal containing periodic transaction rules
 
-all.journal includes all the year journals. 
+all.journal includes all the year journals.
 It provides all historical data, but is slow, and my old journals are inconsistent/broken, so it's currently rarely used.
 
 current.journal is a symlink for scripts which don't know the year.
-Symbolic links are a mixed blessing, causing file path confusion in emacs, eg.
+Symbolic links are a mixed blessing, causing file path confusion in emacs, e.g.
 
 ## Data entry
 
@@ -64,12 +64,12 @@ For troubleshooting: when downloading a CSV the previous copy is saved as FILE.c
 $ make csv
 ```
 
-Cash transactions are entered in emacs, using ledger-mode. 
+Cash transactions are entered in emacs, using ledger-mode.
 Mostly by copying and pasting similar past transactions.
 
-When rewriting account names, I use either 
+When rewriting account names, I use either
 ledger-mode completion (`TAB`) or dabbrev-expand completion (`M-/`),
-which have different strengths. 
+which have different strengths.
 
 I fetch currency prices with barrucadu's market-prices.py script
 ([details](https://gist.github.com/simonmichael/9ca4d74b30567dcc3b93763ffe88abf9)).

--- a/snippets.md
+++ b/snippets.md
@@ -14,26 +14,26 @@
 ``` eval_rst
 :name:   Site snippets
 :description:
-  Miscellaneous examples of how to do things on this site. 
+  Miscellaneous examples of how to do things on this site.
   Follow the edit link to see the page source.
 :author: The Author
 :date:   2019-09-10
-:another field: 
+:another field:
     indented
 
     paragraphs
 
-another field: 
+another field:
     without leading colon, does not have the field-even/field-odd class
 ```
 
 ## Commonmark
 
-This site's native markup is [Commonmark](https://commonmark.org/) markdown, 
+This site's native markup is [Commonmark](https://commonmark.org/) markdown,
 via Sphinx's [recommonmark](https://recommonmark.readthedocs.io/en/latest/index.html) extension.
 Here's Commonmark's syntax: <https://spec.commonmark.org/0.29/>
 
-Forced line breaks: 
+Forced line breaks:
 write `<br>`<br>
 or `\` (backslash)\
 at line end.
@@ -55,7 +55,7 @@ There's also a short form: write the RST directive (dots not necessary) at the s
     ```centered:: Centered text.
     ```
 
-Eg:
+E.g.,
 
 ```centered:: Centered text.
 ```


### PR DESCRIPTION
There are lots of e.g. and i.e. in the docs and they are written as `eg` and `ie`, which are confused sometimes. I'd like to tackle this task by updating those with regular ones.

Following:
- https://www.dailywritingtips.com/comma-after-i-e-and-e-g/
- https://www.instructionalsolutions.com/blog/how-to-use-i-e-and-e-g

And all the docs under the root folder (without changelog.md maybe) and the latest tag-`1.16` will be updated.

Progress:
- [x] Root folder
- [ ] Release notes (TBD)
- [ ] Latest tag 1.16

There are some random diff because of trailing spaces, please ignore that.