### PR TITLE
Revert Arch version hack and link to package info

### DIFF
--- a/src/download.md
+++ b/src/download.md
@@ -241,7 +241,7 @@ https://github.com/simonmichael/hledger/releases, also apply here.
     <tr>
       <td>
         <div class="badges">
-          <a href="https://www.archlinux.org/packages/?sort=&amp;q=hledger"><img alt="Arch" src="https://img.shields.io/badge/Arch_package-1.20.3-red.svg" /></a>  <!-- wrong color, until hledger-web 1.20.1 https://repology.org/badge/version-for-repo/arch/hledger.svg -->
+          <a href="https://archlinux.org/packages/community/x86_64/hledger/"><img alt="Arch" src="https://repology.org/badge/version-for-repo/arch/hledger.svg" /></a>
         </div>
         <div class="distro">Arch</div>
       </td>


### PR DESCRIPTION
This info page will show if any of the subcomponents (like -web) are out
of date, this is what Arch users will expect to see. Repology's badge
plus this page link is more useful than a manual badge hack that is
quickly outdated.

This reverts commit 9b9f3150fdd47d8e46e59c5ca20f75a419a41575.
