### PR TITLE
Fix regex `|` being parsed as markdown table separator

### DIFF
--- a/src/1.21/hledger.md
+++ b/src/1.21/hledger.md
@@ -5069,15 +5069,15 @@ using the following rules:
 
 | If name matches [regular expression](hledger.html#regular-expressions): | account type is: |
 |-------------------------------------------------------------------------|------------------|
-| `^assets?(:|$)`                                                         | `Asset`          |
-| `^(debts?|liabilit(y|ies))(:|$)`                                        | `Liability`      |
-| `^equity(:|$)`                                                          | `Equity`         |
-| `^(income|revenue)s?(:|$)`                                              | `Revenue`        |
-| `^expenses?(:|$)`                                                       | `Expense`        |
+| `^assets?(:\|$)`                                                        | `Asset`          |
+| `^(debts?\|liabilit(y\|ies))(:\|$)`                                     | `Liability`      |
+| `^equity(:\|$)`                                                         | `Equity`         |
+| `^(income\|revenue)s?(:\|$)`                                            | `Revenue`        |
+| `^expenses?(:\|$)`                                                      | `Expense`        |
 
 | If account type is `Asset` and name does not contain regular expression: | account type is: |
 |--------------------------------------------------------------------------|------------------|
-| `(investment|receivable|:A/R|:fixed)`                                    | `Cash`           |
+| `(investment\|receivable\|:A/R\|:fixed)`                                 | `Cash`           |
 
 Even so, explicit declarations may be a good idea, for clarity and
 predictability.


### PR DESCRIPTION
Closes #39.
Looks like [the **DEV** version of the docs](https://hledger.org/dev/hledger.html#auto-detected-account-types) switched the table to just be a code block anyway, but it's still nice to not have broken tables in 1.21 :)