### PR TITLE
Update path to Bash programmable completion script

### DIFF
--- a/src/command-line-completion.md
+++ b/src/command-line-completion.md
@@ -25,8 +25,8 @@ distribution. Refer to the last paragraph of this section for how to test that.
 
 To install the completions manually, follow this steps:
 
-- [Download](https://raw.githubusercontent.com/simonmichael/hledger/master/shell-completion/hledger-completion.bash)
-  or copy the file `shell-completion/hledger-completion.bash` and save
+- [Download](https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash)
+  or copy the file `hledger/shell-completion/hledger-completion.bash` and save
   it as `~/.hledger-completion.bash`.
 
 - Add the command `source ~/.hledger-completion.bash` to the end of your `~/.bashrc` file.
@@ -37,7 +37,7 @@ To install the completions manually, follow this steps:
 Example installation script:
 
 ```
-curl https://raw.githubusercontent.com/simonmichael/hledger/master/shell-completion/hledger-completion.bash > ~/.hledger-completion.bash
+curl https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash > ~/.hledger-completion.bash
 echo 'source ~/.hledger-completion.bash' >> ~/.bashrc
 bash  # open a new bash to try it
 ```
@@ -54,4 +54,4 @@ You're welcome to add completion scripts for other shells (e.g. Fish or Zsh)!
 It should not be too hard. All available hledger options and commands
 are already there. Only the shell hooks and logic is missing.
 
-Please refer to the README in the [shell-completion](https://github.com/simonmichael/hledger/tree/master/shell-completion) folder.
+Please refer to the README in the [shell-completion](https://github.com/simonmichael/hledger/tree/master/hledger/shell-completion) folder.

--- a/src/command-line-completion.md
+++ b/src/command-line-completion.md
@@ -28,6 +28,11 @@ To install the completions manually, follow this steps:
 - [Download](https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash)
   or copy the file `hledger/shell-completion/hledger-completion.bash` and save
   it as `~/.hledger-completion.bash`.
+  
+  _**Note:** Prior to version 1.25, the `shell-completion` directory was at the
+  repository root (not `hledger/shell-completion`). Update the URLs, taking
+  this into account, if you are trying to download the completion script for an
+  older version of hledger such as [1.21](https://raw.githubusercontent.com/simonmichael/hledger/1.21/shell-completion/hledger-completion.bash)._
 
 - Add the command `source ~/.hledger-completion.bash` to the end of your `~/.bashrc` file.
 


### PR DESCRIPTION
Looks like the Bash completion script moved into an `hledger` subdirectory. This updates the relevant documentation to point to the new location.

I did this with the GitHub web interface, so I didn't exhaustively `grep` the rest of the documentation source for other instances, but if you think there might be others, I'm happy to dig deeper and push another commit to this PR.

Lastly, if one has [bash-completion](https://github.com/scop/bash-completion) already installed, you can

```bash
mkdir -p ~/.local/share/bash-completion/completions
curl https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash \
  > ~/.local/share/bash-completion/completions/hledger
```

…and let bash-completion take care of the rest. If you feel that including this would add value to the docs, I can add a note about that to the PR as well.