### PR TITLE
Update editors.md for neovim syntax support

### DIFF
--- a/src/editors.md
+++ b/src/editors.md
@@ -202,6 +202,10 @@ A helper to browse TODO tags in the journal:
 
 <https://github.com/linuxcaffe/timedot-vim>
 
+## Neovim
+
+Run `:TSInstall ledger` to enable [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter#language-parsers) for hledger.
+
 ## VS Code
 
 ### hledger-vscode


### PR DESCRIPTION
Neovim uses tree-sitter (a parsing library) through nvim-treesitter, and supports *ledger syntax parsing and highlighting out of the box if the user runs the command. Making it obvious to neovim users what are the steps to enable hledger support.