### PR TITLE
fix: if table link for if block

### DIFF
--- a/src/1.31/hledger.md
+++ b/src/1.31/hledger.md
@@ -3635,7 +3635,7 @@ There\'s not yet an easy syntax to negate a matcher.
 
 ### `if` table
 
-\"if tables\" are an alternative to [if blocks](#if-blocks); they can
+\"if tables\" are an alternative to [if blocks](#if-block); they can
 express many matchers and field assignments in a more compact tabular
 format, like this:
 


### PR DESCRIPTION
The text can say if blocks but the valid link is `#if-block` with no s (https://hledger.org/1.31/hledger.html#if-block)