### PR TITLE
Update completion installation location

### DIFF
--- a/src/command-line-completion.md
+++ b/src/command-line-completion.md
@@ -27,14 +27,12 @@ To install the completions manually, follow this steps:
 
 - [Download](https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash)
   or copy the file `hledger/shell-completion/hledger-completion.bash` and save
-  it as `~/.hledger-completion.bash`.
+  it as `${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions`.
   
   _**Note:** Prior to version 1.25, the `shell-completion` directory was at the
   repository root (not `hledger/shell-completion`). Update the URLs, taking
   this into account, if you are trying to download the completion script for an
   older version of hledger such as [1.21](https://raw.githubusercontent.com/simonmichael/hledger/1.21/shell-completion/hledger-completion.bash)._
-
-- Add the command `source ~/.hledger-completion.bash` to the end of your `~/.bashrc` file.
 
 - Then, you have to start a new Bash, e.g. by typing `bash` on the current
   shell.
@@ -42,8 +40,8 @@ To install the completions manually, follow this steps:
 Example installation script:
 
 ```
-curl https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash > ~/.hledger-completion.bash
-echo 'source ~/.hledger-completion.bash' >> ~/.bashrc
+url='https://raw.githubusercontent.com/simonmichael/hledger/master/hledger/shell-completion/hledger-completion.bash'
+curl "$url" > "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions"
 bash  # open a new bash to try it
 ```
 


### PR DESCRIPTION
Update recommended installation location in view of 3ab796f promoting bash-completions standard locations.
Also pull out url from installation script to make edits stand out better.