### PR TITLE
Make raw version URLs redirect to hledger.html

### DIFF
--- a/hledger.org.caddy
+++ b/hledger.org.caddy
@@ -352,6 +352,12 @@ hledger.org {
 	# for fun
 	redir /DEBITS.html /CREDITS.html
 
+	@versionRoots {
+		path_regexp version ^/(\d+\.\d+)/?$
+	}
+
+	redir @versionRoots {1}/hledger.html
+
 	# rewrites
 
 	# rewrite any slug without an extension, to the .html form


### PR DESCRIPTION
Redirect URLs like `https://hledger.org/1.41` or `https://hledger.org/1.41/` to `https://hledger.org/1.41/hledger.html` (or whichever version is appropriate).

I tested this in a Docker instance of Caddy and it seems to work correctly without affecting anything else.