### PR TITLE
Use blockquotes and freeze mdbook version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ all buildall: \
 # Install some required tools.
 # --force rebuilds mdbook-toc even if only mdbook changed, avoiding a warning.
 tools:
-	cargo install mdbook mdbook-toc --force
+	cargo install mdbook --version 0.4.22 --force
+	cargo install mdbook-toc --force
 	sudo apt install -y npm && npm install -g static-sitemap-cli   # sscli
 
 

--- a/README
+++ b/README
@@ -29,6 +29,11 @@ the website via symbolic links in src/. These are:
   These should be generated/updated before rendering the website, by
   doing "make Shake && ./Shake" webmanuals in the main hledger repo.
 
+To install the necessary tools on Debian or Ubuntu (assuming Rust is
+installed):
+
+  sudo apt update && make tools
+
 To render the latest site content (in out/): 
 
     make

--- a/README
+++ b/README
@@ -44,3 +44,7 @@ built separately due to mdbook limitations):
 
     make buildall
 
+Depending on how the repository is cloned, it may be necessary to
+delete the existing highslide symlink in the root directory with a new
+symlink to src/highslide in order to prevent a build error about a
+path not being a directory.

--- a/src/index.md
+++ b/src/index.md
@@ -40,18 +40,28 @@ Robust, friendly, fast<br> plain text accounting software
 
 <div id="quotes">
 
-*I discovered hledger last week and I hope it's not too early to describe it as life-changing. thank you for building this software --gnidan*
+> I discovered hledger last week and I hope it's not too early to describe it as life-changing. thank you for building this software
+>
+> ― <cite>gnidan</cite>
 
-*I have massively enjoyed using hledger and am incredibly impressed with how active the development and support for it are! --Pixelized*
+> I have massively enjoyed using hledger and am incredibly impressed with how active the development and support for it are!
+>
+> ― <cite>Pixelized</cite>
 
-*I completed my first year of bookkeeping for both business and personal expenses with hledger last year. I can honestly say that I observed zero bugs with the software. It has worked seamlessly. --csgagnon*
+> I completed my first year of bookkeeping for both business and personal expenses with hledger last year. I can honestly say that I observed zero bugs with the software. It has worked seamlessly.
+>
+> ― <cite>csgagnon</cite>
 
-*I've been using hledger for managing my personal finances for a few years now, and I'm really happy with it! --guivho*
+> I've been using hledger for managing my personal finances for a few years now, and I'm really happy with it!
+>
+> ― <cite>guivho</cite>
 
-*hledger focuses on testing and correctness alongside comprehensive documentation, giving me a much better picture of its capabilities.
-I dove in and spent a week entering a year and a half of data, which was enough to convince me.
-hledger is truly an amazing tool. I can’t count how many times I’ve thought wouldn’t it be nice if… only to realize it can already do that ... 
-The attention to detail is marvelous. --Shiv J. M.*
+> hledger focuses on testing and correctness alongside comprehensive documentation, giving me a much better picture of its capabilities.
+> I dove in and spent a week entering a year and a half of data, which was enough to convince me.
+> hledger is truly an amazing tool. I can’t count how many times I’ve thought wouldn’t it be nice if… only to realize it can already do that […]
+> The attention to detail is marvelous.
+>
+> ― <cite>Shiv J.M.</cite>
 
 [![Github repo](https://img.shields.io/github/stars/simonmichael/hledger.svg?logo=GitHub&label=Github+stars&color=brightgreen)](https://github.com/simonmichael/hledger)
 [![GitHub downloads, latest](https://img.shields.io/github/downloads/simonmichael/hledger/latest/total?logo=GitHub&label=Github+downloads,+latest&color=brightgreen)](https://github.com/simonmichael/hledger/releases/latest)

--- a/theme/css/general.css
+++ b/theme/css/general.css
@@ -175,3 +175,24 @@ blockquote {
     margin: 5px 0px;
     font-weight: bold;
 }
+
+blockquote {
+    padding: 1em 1.25em;
+}
+
+blockquote > p:has(cite) {
+    margin-top: 0;
+    text-align: right;
+}
+
+blockquote > p > cite {
+    font-style: normal;
+}
+
+p {
+    margin: 0;
+}
+
+* + p {
+    margin-top: 1em;
+}


### PR DESCRIPTION
* Use `blockquote` & `cite` for the testimonials on the homepage
* Style `p`s globally only with top margins (for consistency)
* Explain tool installation and symlink issue in README
* Explicitly install mdbook v0.4.22 in Makefile

I tried to make sure no styling is disturbed with the change to the `p`s. This is how the top of the homepage looks now (blockquotes were already being styled):

![Testimonials with `blockquote` and `cite`](https://github.com/user-attachments/assets/25052284-a609-44bc-93f4-e2b880accb16)

Apart from that, as I mentioned on Matrix, the latest versions  of mdbook (v0.4.47 onwards) fail to build the site, so I added an explicit version to the Makefile. I also expanded the README to cover the tools and an error I encountered.