### PR TITLE
obsidian: add plugin descriptions, mark archived status, add tutorial and discussion sections

### DIFF
--- a/src/obsidian.md
+++ b/src/obsidian.md
@@ -1,11 +1,32 @@
 # hledger and Obsidian
 
+Plugins and tutorials for using hledger from inside an Obsidian vault.
+
+## Hledger Notes
+
+Manage hledger transactions inside your Obsidian vault. Daily-note
+integration, fuzzy account autosuggest, multi-currency support, and
+import/export between daily notes and journal files. Available in the
+Obsidian Community Plugin directory.
+
+- <https://obsidian.md/plugins?id=hledger-notes>
+- <https://github.com/bzimor/obsidian_hledger>
+- <https://forum.obsidian.md/t/plugin-for-plaintext-accounting-enthusiasts-hledger-notes/100861>
+- <https://www.reddit.com/r/ObsidianMD/comments/v6egmh/i_wrote_script_using_templater_to_add_hledger/>
+
 ## ledger-obsidian
+
+Ledger-format plain text accounting inside Obsidian, with a quick-entry
+widget. Compatible with hledger's reading mode for the same journal
+format. No longer maintained as of July 2024.
 
 - <https://github.com/tgrosinger/ledger-obsidian>
 - <https://www.reddit.com/r/ObsidianMD/comments/u9osib/anyone_out_there_using_the_ledger_plugin/>
 
-## obsidian_hledger
+## Tutorials
 
-- <https://github.com/bzimor/obsidian_hledger>
-- <https://www.reddit.com/r/ObsidianMD/comments/v6egmh/i_wrote_script_using_templater_to_add_hledger/>
+- [Personal Finance in Obsidian with hledger and Claude Code](https://mandalivia.com/obsidian/hledger-obsidian-personal-finance-with-claude-code/) (2026) — setup guide to use hledger alongside Obsidian and Claude Code.
+
+## Discussion
+
+- [Plain text accounting with Obsidian](https://forum.plaintextaccounting.org/t/plain-text-accounting-with-obsidian/553) — PTA forum thread.


### PR DESCRIPTION
Fill out the obsidian page.

The page is currently two plugin names with bare URLs and no description, which makes it hard for someone landing here from search to know which plugin does what or whether they're maintained. This PR:

- Adds short factual descriptions for each plugin, matching the style of mobile.md and editors.md.
- Reorders with the actively-maintained plugin (Hledger Notes) first; ledger-obsidian's archived status (July 2024) is stated explicitly so users don't waste time installing an unmaintained plugin.
- Adds the Obsidian Community Plugin Directory link for Hledger Notes — the install path most users want, separate from the GitHub source.
- Adds the Hledger Notes Obsidian forum thread alongside the existing Reddit links.
- Adds a Tutorials section with one article I wrote (disclosing here) about hledger + Obsidian + Claude Code. No other published tutorials on this topic surfaced in my research; happy to drop the section or revise the entry if it doesn't fit.
- Adds a Discussion section pointing to the PTA forum thread.

All links verified as of 2026-05-25.